### PR TITLE
Native Tor support

### DIFF
--- a/docs/Using OpenBazaar with Tor.md
+++ b/docs/Using OpenBazaar with Tor.md
@@ -12,33 +12,38 @@ Before you go any further please consider the following: OpenBazaar is pre-relea
 
 There are two methods for getting OpenBazaar working with Tor:
 
-1. Proxychains - Using a socket hooking application called proxychains to redirect all OpenBazaar traffic through a Tor SOCKS proxy
+1. Native support using 'Tor mode' - a fork of the development branch currently implements 'Tor mode' which routes all inter-node traffic via Tor and uses hidden services to expose OB edpoints
 2. Onioncat - Using an application called Onioncat to create an IPv6 TUN interface which is associated with a Tor Hidden Service and then running OpenBazaar
 
-####Proxychains pro's
-- Does not require root access to system
-- Simpler of the two methods
+####Native 'Tor mode' pro's
+- By far the simplest approach
+- Much faster
+- No external dependenices or root access required
+- Less chance of IP address leakage
 
-####Proxychains con's
+####Native 'Tor mode' con's
 - Requires the creation of a hidden service (for current releases of OB)
-- Does not work correctly yet - the advertised node URI needs to be the hidden services hostname
+- Is only available on a fork at present
+- Requires Tor-Mode seeds, cannot communicate with the existing OB public seeds
 
 ####Onioncat pro's
 - Completely isolated from non Onioncat (thus non-Tor) systems
-- Works now as incoming connections are supported
+- Works on both master annd develop branches (Tor mode support not necessary)
 
 ####Onioncat con's
 - Requires the creation of a hidden service (for current releases of OB)
 - Require creation of bi-directional Onioncat configuration which needs to be defended (firewalled etc)
+- Requires Onioncat enabled seeds, cannot communicate with the existing OB public seeds
 
+## 2. NATIVE 'TOR MODE'
 
-## 2. PROXYCHAINS
-
-1. Install the Proxychains package
+1. Create a hidden service for your OpenBazaar server listener
+  - Configure as follows: Listen on port 12345. Redirect to 127.0.0.1:12345. 
+  - Restart Tor and make a note of the hidden service hostname that is created for you.
 2. Start OpenBazaar with :
-` proxychains ./openbazaar -j start'
+` openbazaar start -t -s fksu5carj3okqfan.onion -i xxxyyyzzz.onion    (where xxxyyyzzz.onion is the hidden service hostname from step 1)
 
-## 3. ONIONCAT
+## 3. ONIONCAT (instructions for master up to 0.2.2)
 
 1. Create a hidden service for Onioncat
   - Configure as follows: Listen on port 8060. Redirect to 127.0.0.1:8060. 

--- a/docs/Using OpenBazaar with Tor.md
+++ b/docs/Using OpenBazaar with Tor.md
@@ -40,10 +40,10 @@ There are two methods for getting OpenBazaar working with Tor:
 1. Create a hidden service for your OpenBazaar server listener
   - Configure as follows: Listen on port 12345. Redirect to 127.0.0.1:12345. 
   - Restart Tor and make a note of the hidden service hostname that is created for you.
-2. Start OpenBazaar with :
-` openbazaar start -t -s fksu5carj3okqfan.onion -i xxxyyyzzz.onion    (where xxxyyyzzz.onion is the hidden service hostname from step 1)
+2. Start OpenBazaar with :<br/>
+` openbazaar -t -s fksu5carj3okqfan.onion -i xxxyyyzzz.onion start`    (where xxxyyyzzz.onion is the hidden service hostname from step 1)
 
-## 3. ONIONCAT (instructions for master up to 0.2.2)
+## 3. ONIONCAT
 
 1. Create a hidden service for Onioncat
   - Configure as follows: Listen on port 8060. Redirect to 127.0.0.1:8060. 

--- a/node/connection.py
+++ b/node/connection.py
@@ -14,7 +14,7 @@ import constants
 from crypto_util import Cryptor
 from guid import GUIDMixin
 import network_util
-from tor_util import *
+from tor_util import TorRedirector
 
 class PeerConnection(object):
     def __init__(self, transport, address, nickname=""):
@@ -48,8 +48,7 @@ class PeerConnection(object):
             # Currently only '.onion' hosts are routed through Tor.
             # TBC : If --Tor-mode flag is set then route all outbound connections through Tor
             if str(ip).endswith('.onion'):
-                print ip+':'+str(port)
-                self.torsock = TorRedirector(ip,port)
+                self.torsock = TorRedirector(ip, port)
                 self.torsock.start()
                 self.socket.connect('tcp://127.0.0.1:%s' % self.torsock.localport)
             else:

--- a/node/constants.py
+++ b/node/constants.py
@@ -52,5 +52,9 @@ checkRefreshInterval = refreshTimeout / 5
 # [bytes]
 udpDatagramMaxSize = 8192  # 8 KB
 
+# ##################### OTHER CONSTANTS
 DB_PATH = "db/ob.db"
 VERSION = "0.3.1.dev0"
+SOCKS5_PROXY_HOST = "127.0.0.1"
+SOCKS5_PROXY_PORT = 9050
+

--- a/node/openbazaar.py
+++ b/node/openbazaar.py
@@ -69,7 +69,7 @@ def create_argument_parser():
         ('--disable-stun-check',),
         ('--disable-upnp', '-j'),
         ('--enable-ip-checker',),
-        ('--tor-mode',),
+        ('--tor-mode', '-t'),
         ('--seed-mode', '-S')
     )
     for switches in flags:

--- a/node/openbazaar_daemon.py
+++ b/node/openbazaar_daemon.py
@@ -69,7 +69,8 @@ class OpenBazaarContext(object):
                  disable_stun_check,
                  disable_open_browser,
                  disable_sqlite_crypt,
-                 enable_ip_checker):
+                 enable_ip_checker,
+                 tor_mode):
         self.nat_status = nat_status
         self.server_ip = server_ip
         self.server_port = server_port
@@ -91,6 +92,7 @@ class OpenBazaarContext(object):
         self.disable_open_browser = disable_open_browser
         self.disable_sqlite_crypt = disable_sqlite_crypt
         self.enable_ip_checker = enable_ip_checker
+        self.tor_mode = tor_mode
 
         # to deduct up-time, and (TODO) average up-time
         # time stamp in (non-local) Coordinated Universal Time format.
@@ -116,6 +118,7 @@ class OpenBazaarContext(object):
              "disable_open_browser": self.disable_open_browser,
              "disable_sqlite_crypt": self.disable_sqlite_crypt,
              "enable_ip_checker": self.enable_ip_checker,
+             "tor_mode": self.tor_mode,
              "started_utc_timestamp": self.started_utc_timestamp,
              "uptime_in_secs": (long(time.time()) -
                                 long(self.started_utc_timestamp))}
@@ -155,6 +158,7 @@ class OpenBazaarContext(object):
                 'bm_pass': None,
                 'bm_port': -1,
                 'enable_ip_checker': False,
+                'tor_mode': False,
                 'config_file': None}
 
     @staticmethod
@@ -181,7 +185,8 @@ class OpenBazaarContext(object):
             disable_stun_check=defaults['disable_stun_check'],
             disable_open_browser=defaults['disable_open_browser'],
             disable_sqlite_crypt=defaults['disable_sqlite_crypt'],
-            enable_ip_checker=defaults['enable_ip_checker']
+            enable_ip_checker=defaults['enable_ip_checker'],
+            tor_mode=defaults['tor_mode']
         )
 
 

--- a/node/tor_util
+++ b/node/tor_util
@@ -1,0 +1,81 @@
+import socks
+import sys
+import socket
+from socket import *
+from threading import Thread
+import time
+
+
+LOGGING = 1
+
+def log(s):
+    if LOGGING:
+        print '%s: Tor Redirector: %s' % ( time.ctime(), s )
+        sys.stdout.flush()
+
+class TorRedirector( Thread ):
+    def __init__(self, targethost, targetport):
+        Thread.__init__( self )
+        # socksiPy errors if given a unicode address which OB sometimes generates - so we force ascii
+        self.targethost = str(targethost).encode('ascii')
+        self.targetport = targetport
+        self.sock = socket( AF_INET, SOCK_STREAM )
+        self.sock.bind(('', 0)) # bind to an available socket
+        self.localport = self.sock.getsockname()[1]
+        log( 'Bound to 127.0.0.1:%s -> %s:%s' % ( self.localport, self.targethost, self.targetport))
+        self.sock.listen(5)
+
+    def run( self ):
+        ClientSock, address = self.sock.accept()
+        log( 'Tor Redirector: Client connected from %s, connecting to %s:%s' % (address, self.targethost, self.targetport))
+        RemoteSock = socks.socksocket( AF_INET, SOCK_STREAM )
+        RemoteSock.setproxy(socks.PROXY_TYPE_SOCKS5, "127.0.0.1", 9050, True)
+        try:
+            RemoteSock.connect(( self.targethost, self.targetport))
+        except:
+            log('Error connecting to target host via Tor')
+            ClientSock.close()
+            RemoteSock.close()
+            self.sock.close()
+            return
+        ClientSock.settimeout(0.1)
+        RemoteSock.settimeout(0.1)
+        while 1:
+            try:
+                dataout = ClientSock.recv(1024000)
+                if not dataout:
+                    log('Client disconnected')
+                    break
+                RemoteSock.send( dataout )
+            except Exception, e:
+                if e.args[0] == 'timed out':
+                    pass  # ignore timeouts
+                else:
+                    log('Error ' + e.args[0])
+                    break
+            try:
+                datain = RemoteSock.recv(1024000)
+                if not datain:
+                    log('Remote host disconnected')
+                    break
+                ClientSock.send( datain )
+            except Exception, e:
+                if e.args[0] == 'timed out':
+                    pass  # ignore timeouts
+                else:
+                    log('Error ' + e.args[0])
+                    break
+
+        ClientSock.close()
+        RemoteSock.close()
+        self.sock.close()
+        print ('Tor Redirector: Exiting')
+
+if __name__ == '__main__':
+
+    print 'Starting Tor Redirector'
+
+    import sys
+    targetport = int( sys.argv[1] )
+    targethost = sys.argv[2]
+    TorRedirector( targethost, targetport ).start()

--- a/node/tor_util.py
+++ b/node/tor_util.py
@@ -1,38 +1,40 @@
 import socks
 import sys
-import socket
-from socket import *
+from socket import socket, AF_INET, SOCK_STREAM
 from threading import Thread
 import time
 
 
 LOGGING = 1
 
+
 def log(s):
     if LOGGING:
-        print '%s: Tor Redirector: %s' % ( time.ctime(), s )
+        print '%s: Tor Redirector: %s' % (time.ctime(), s)
         sys.stdout.flush()
 
-class TorRedirector( Thread ):
+
+class TorRedirector(Thread):
     def __init__(self, targethost, targetport):
-        Thread.__init__( self )
+        Thread.__init__(self)
         # socksiPy errors if given a unicode address which OB sometimes generates - so we force ascii
         self.targethost = str(targethost).encode('ascii')
         self.targetport = targetport
-        self.sock = socket( AF_INET, SOCK_STREAM )
-        self.sock.bind(('', 0)) # bind to an available socket
+        self.sock = socket(AF_INET, SOCK_STREAM)
+        self.sock.bind(('', 0))  # bind to an available socket
         self.localport = self.sock.getsockname()[1]
-        log( 'Bound to 127.0.0.1:%s -> %s:%s' % ( self.localport, self.targethost, self.targetport))
+        log('Bound to 127.0.0.1:%s -> %s:%s' % (self.localport, self.targethost, self.targetport))
         self.sock.listen(5)
 
-    def run( self ):
+    def run(self):
         ClientSock, address = self.sock.accept()
-        log( 'Tor Redirector: Client connected from %s, connecting to %s:%s' % (address, self.targethost, self.targetport))
-        RemoteSock = socks.socksocket( AF_INET, SOCK_STREAM )
+        log('Tor Redirector: Client connected from %s, connecting to %s:%s' % (
+            address, self.targethost, self.targetport))
+        RemoteSock = socks.socksocket(AF_INET, SOCK_STREAM)
         RemoteSock.setproxy(socks.PROXY_TYPE_SOCKS5, "127.0.0.1", 9050, True)
         try:
-            RemoteSock.connect(( self.targethost, self.targetport))
-        except:
+            RemoteSock.connect((self.targethost, self.targetport))
+        except socks.Socks5Error:
             log('Error connecting to target host via Tor')
             ClientSock.close()
             RemoteSock.close()
@@ -46,7 +48,7 @@ class TorRedirector( Thread ):
                 if not dataout:
                     log('Client disconnected')
                     break
-                RemoteSock.send( dataout )
+                RemoteSock.send(dataout)
             except Exception, e:
                 if e.args[0] == 'timed out':
                     pass  # ignore timeouts
@@ -58,7 +60,7 @@ class TorRedirector( Thread ):
                 if not datain:
                     log('Remote host disconnected')
                     break
-                ClientSock.send( datain )
+                ClientSock.send(datain)
             except Exception, e:
                 if e.args[0] == 'timed out':
                     pass  # ignore timeouts
@@ -69,13 +71,12 @@ class TorRedirector( Thread ):
         ClientSock.close()
         RemoteSock.close()
         self.sock.close()
-        print ('Tor Redirector: Exiting')
+        log('Exiting')
+
 
 if __name__ == '__main__':
-
     print 'Starting Tor Redirector'
 
-    import sys
-    targetport = int( sys.argv[1] )
-    targethost = sys.argv[2]
-    TorRedirector( targethost, targetport ).start()
+    ptargetport = int(sys.argv[1])
+    ptargethost = sys.argv[2]
+    TorRedirector(ptargethost, ptargetport).start()

--- a/node/tor_util.py
+++ b/node/tor_util.py
@@ -3,10 +3,9 @@ import sys
 from socket import socket, AF_INET, SOCK_STREAM
 from threading import Thread
 import time
-
+import constants
 
 LOGGING = 1
-
 
 def log(s):
     if LOGGING:
@@ -27,13 +26,11 @@ class TorRedirector(Thread):
         self.localport = self.sock.getsockname()[1]
         log('Bound to 127.0.0.1:%s -> %s:%s' % (self.localport, self.targethost, self.targetport))
         self.sock.listen(5)
-
     def run(self):
         ClientSock, address = self.sock.accept()
-        log('Client connected from %s, connecting to %s:%s' % (
-            address, self.targethost, self.targetport))
+        log('Client connected from %s, connecting to %s:%s' % (address, self.targethost, self.targetport))
         RemoteSock = socks.socksocket(AF_INET, SOCK_STREAM)
-        RemoteSock.setproxy(socks.PROXY_TYPE_SOCKS5, "127.0.0.1", 9050, True)
+        RemoteSock.setproxy(socks.PROXY_TYPE_SOCKS5, constants.SOCKS5_PROXY_HOST, constants.SOCKS5_PROXY_PORT, True)
         try:
             RemoteSock.connect((self.targethost, self.targetport))
         except socks.Socks5Error:

--- a/node/tor_util.py
+++ b/node/tor_util.py
@@ -13,6 +13,8 @@ def log(s):
         print '%s: Tor Redirector: %s' % (time.ctime(), s)
         sys.stdout.flush()
 
+def is_onion_addr(addr):
+    return addr.endswith(".onion")
 
 class TorRedirector(Thread):
     def __init__(self, targethost, targetport):
@@ -28,7 +30,7 @@ class TorRedirector(Thread):
 
     def run(self):
         ClientSock, address = self.sock.accept()
-        log('Tor Redirector: Client connected from %s, connecting to %s:%s' % (
+        log('Client connected from %s, connecting to %s:%s' % (
             address, self.targethost, self.targetport))
         RemoteSock = socks.socksocket(AF_INET, SOCK_STREAM)
         RemoteSock.setproxy(socks.PROXY_TYPE_SOCKS5, "127.0.0.1", 9050, True)

--- a/node/transport.py
+++ b/node/transport.py
@@ -38,6 +38,7 @@ class TransportLayer(object):
         self.nickname = nickname
         self.handler = None
         self.uri = network_util.get_peer_url(self.ip, self.port)
+        self.tor_mode = ob_ctx.tor_mode
         self.listener = None
 
         # Create one ZeroMQ context to be reused and reduce overhead
@@ -98,7 +99,7 @@ class CryptoTransportLayer(TransportLayer):
         self.ip = ob_ctx.server_ip
         self.nickname = ""
         self.dev_mode = ob_ctx.dev_mode
-
+        self.tor_mode = ob_ctx.tor_mode
         self.all_messages = (
             'hello',
             'findNode',
@@ -112,7 +113,7 @@ class CryptoTransportLayer(TransportLayer):
         TransportLayer.__init__(self, ob_ctx, self.guid, self.nickname)
         self.start_listener()
 
-        if ob_ctx.enable_ip_checker and not ob_ctx.seed_mode and not ob_ctx.dev_mode:
+        if ob_ctx.enable_ip_checker and not ob_ctx.seed_mode and not ob_ctx.dev_mode and not ob_ctx.tor_mode:
             self.start_ip_address_checker()
 
     def start_listener(self):
@@ -130,7 +131,7 @@ class CryptoTransportLayer(TransportLayer):
         self.listener = connection.CryptoPeerListener(
             self.ip, self.port, self.pubkey, self.secret, self.ctx,
             self.guid,
-            self._on_message
+            self._on_message,self.tor_mode
         )
 
         self.listener.set_ok_msg({
@@ -397,9 +398,9 @@ class CryptoTransportLayer(TransportLayer):
             '\nNickname:%s',
             guid, uri, pubkey, nickname
         )
-
+        tm = self.tor_mode
         return connection.CryptoPeerConnection(
-            self, uri, pubkey, guid=guid, nickname=nickname
+            self, uri, tm, pubkey, guid=guid, nickname=nickname
         )
 
     def respond_pubkey_if_mine(self, nickname, ident_pubkey):

--- a/node/transport.py
+++ b/node/transport.py
@@ -129,9 +129,9 @@ class CryptoTransportLayer(TransportLayer):
         ])
 
         self.listener = connection.CryptoPeerListener(
-            self.ip, self.port, self.pubkey, self.secret, self.ctx,
+            self.ip, self.port, self.tor_mode, self.pubkey, self.secret, self.ctx,
             self.guid,
-            self._on_message,self.tor_mode
+            self._on_message
         )
 
         self.listener.set_ok_msg({

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ python-obelisk==0.1.3
 pyzmq==14.3.1
 qrcode==5.0.1
 requests==2.4.1
+socksipy-branch==1.01
 tornado==4.0.2
 Twisted==14.0.2

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -17,6 +17,7 @@ class TestPeerConnection(unittest.TestCase):
         cls.protocol = "tcp"
         cls.hostname = "crypto.io"
         cls.port = 54321
+        cls.tor_mode = False
         cls.address = cls._mk_address(cls.protocol, cls.hostname, cls.port)
         cls.nickname = "OpenBazaar LightYear"
         cls.pub = "YELLOW SUBMARINE"
@@ -26,10 +27,11 @@ class TestPeerConnection(unittest.TestCase):
         cls.default_nickname = ""
 
     def setUp(self):
-        self.pc1 = connection.PeerConnection(self.transport, self.address)
+        self.pc1 = connection.PeerConnection(self.transport, self.address, self.tor_mode)
         self.pc2 = connection.PeerConnection(
             self.transport,
             self.address,
+            self.tor_mode,
             self.nickname
         )
 
@@ -37,6 +39,7 @@ class TestPeerConnection(unittest.TestCase):
         self.assertEqual(self.pc1.timeout, self.timeout)
         self.assertEqual(self.pc1.transport, self.transport)
         self.assertEqual(self.pc1.address, self.address)
+        self.assertEqual(self.pc1.tor_mode, self.tor_mode)
         self.assertEqual(self.pc1.nickname, self.default_nickname)
         self.assertIsNotNone(self.pc1.ctx)
 
@@ -61,6 +64,7 @@ class TestCryptoPeerConnection(TestPeerConnection):
         return connection.CryptoPeerConnection(
             cls.transport,
             cls.address,
+            cls.tor_mode
         )
 
     @classmethod
@@ -68,6 +72,7 @@ class TestCryptoPeerConnection(TestPeerConnection):
         return connection.CryptoPeerConnection(
             cls.transport,
             cls.address,
+            cls.tor_mode,
             cls.pub,
             cls.guid,
             cls.nickname,
@@ -96,6 +101,7 @@ class TestCryptoPeerConnection(TestPeerConnection):
         self.assertEqual(self.pc1.ip, self.hostname)
         self.assertEqual(self.pc1.port, self.port)
         self.assertEqual(self.pc1.address, self.address)
+        self.assertEqual(self.pc1.tor_mode, self.tor_mode)
 
         self.assertEqual(self.pc1.pub, self.default_pub)
         self.assertEqual(self.pc1.sin, self.default_sin)
@@ -118,7 +124,8 @@ class TestCryptoPeerConnection(TestPeerConnection):
                 self.pc1,
                 connection.CryptoPeerConnection(
                     self.transport,
-                    address
+                    address,
+                    self.tor_mode
                 )
             )
 
@@ -133,6 +140,7 @@ class TestCryptoPeerConnection(TestPeerConnection):
             connection.CryptoPeerConnection(
                 self.transport,
                 self.address,
+                self.tor_mode,
                 self.pub,
                 another_guid,
                 self.nickname,


### PR DESCRIPTION
This PR is intended to add Native Tor support to OpenBazaar.

Given that zmq does not support name resolution via SOCKS it has been necessary to create a small TCP redirector within PeerConnection that allows zmq sockets to be routed via SOCKS/Tor.

Currently this PR will allow any node to connect via Tor (using --tor-mode or -t) although only other Tor-mode nodes will be visible. Functionality is the same as non-Tor mode. To receive connections you will need to configure a Hidden Service in Tor and point the hidden service port at your local OpenBazaar server port (usually 12345).

This PR is currently running a Native Tor seed node operating at tcp://fksu5carj3okqfan.onion:12345 suitable for test purposes if you wish. 

You may access the web interface of a demo client here: http://fksu5carj3okqfan.onion

Summary of changes:
1) Tor mode added to the launcher
2) socksiPy-branch has been added to requirements.txt
3) A utility library file called tor_util.py has been created that currently contains a redirector class - TorRedirector 
4) PeerConnection._initiate_connection in connection.py has been modified to call TorRedirector when a zmq peerconnection via Tor is required
5) An '.onion' hostname may be specified for your nodes local IP using '-i'
6) In tor-mode all zmq peerlistener sockets and peerconnection sockets bind to localhost only

Outstanding Changes
1) Ensure that other connections such as those to blockchain and Obelisk go via Tor 

A background medium-long term goal should be to fully implement SOCKS5 with name resolution into zmq itself at which point the redirector element would become redundant.