### PR TITLE
Ansible setup scripts for Ubuntu and Debian

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "trusty32"
   config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
-
+ 
+  config.vm.provision "ansible" do |ansible|
+     ansible.playbook = "ansible-provisioning/openbazaar_linux.yml"
+     ansible.verbose = true
+     # can change provisioning config using extra vars:
+     # ansible.extra_vars = { from_github: false, copy_from_local_directory: '/home/users/Projects/OpenBazaar-clean/' } 
+  end
 
   #This stanza makes use of the vagrant-cachier tool to cache apt updates while refreshing virtual machines -sbl
   if Vagrant.has_plugin?("vagrant-cachier")
@@ -34,18 +40,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
    end
 
   config.vm.synced_folder ".", "/vagrant",  :mount_options => ["dmode=755,fmode=755"]
-
-  config.vm.provision "shell", inline: <<-SCRIPT
-    apt-get update
-    apt-get install -y build-essential python-dev python-pip python-zmq sqlite3 libjpeg-dev tor privoxy gnupg rng-tools mongodb-clients libssl-dev lintian libjs-jquery
-    pip install -r requirements.txt
-    #easy_install sqlite3dbm websocket behave
-    easy_install sqlite_dbm websocket behave bitcoin
-    cp -R /vagrant/ecdsa /usr/local/lib/python2.7/dist-packages/
-    mongo --eval "db = db.getSiblingDB('openbazaar')"
-    sudo rngd -r /dev/urandom
-    /etc/init.d/tor restart
-  SCRIPT
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.

--- a/ansible-provisioning/README.md
+++ b/ansible-provisioning/README.md
@@ -1,0 +1,32 @@
+# Installing Open Bazaar in a Vagrant vm
+You need to have the ansible package installed (available by brew for Mac and by apt-get for Ubuntu).
+ Then, simply run 
+```
+vagrant up
+````
+from this directory or its parent. 
+
+If you get any messages of the machine already having been provisioned, do:
+```
+vagrant provision
+```
+Now you should be able to visit Open Bazaar at:
+http://192.168.33.10:55555/
+
+If you get connection errors, edit your ~/.ssh/config to have this line:
+```
+# for vagrant provisioning
+Host 127.0.0.1
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null
+```
+
+# Installing Open Bazaar in machine(s) where you have ssh access to
+
+Write a host name in every line of the file hosts.conf for every host you want to install Open Bazaar on. You need a user with sudo access.
+You can either modify the vars section in openbazaar_linux.yml to change them with your preferred values or specify them at the command line as extra-vars (command line vars will override the vars in the yml file)
+Example:
+
+```
+ansible-playbook openbazaar_linux.yml -i hosts.conf -u ssh_user --private-key=~/path/to/private/key -vvvv --extra-vars "do_system_update=False port=22222"
+```

--- a/ansible-provisioning/openbazaar_linux.yml
+++ b/ansible-provisioning/openbazaar_linux.yml
@@ -1,0 +1,97 @@
+# Install openbazaar on remote hosts
+# by copying the data from directory on current host or github
+# installs dependencies  and launches OB daemon
+# Supported OS : Ubuntu, Debian
+
+- hosts: all 
+  vars:
+    from_github: True
+    repo_url: https://github.com/OpenBazaar/OpenBazaar.git 
+    branch: master 
+    copy_from_local_directory: /home/user/Projects/OpenBazaar # if from_github=False, then will try to copy from this directory
+    openbazaar_toplevel_dest: /home/vagrant
+    openbazaar_python_venv: /home/vagrant/OpenBazaar/env
+    ip: 0.0.0.0
+    port: 55555
+    do_test: False
+    do_system_update: True
+    reqs:
+      - python-pip
+      - build-essential 
+      - python-zmq
+      - rng-tools 
+      - python-dev
+      - libjpeg-dev
+      - sqlite3
+      - openssl 
+      - alien 
+      - libssl-dev 
+      - python-virtualenv
+      - lintian
+      - libjs-jquery
+      - haveged # to generate entropy for PGP :)
+  sudo: False
+
+  tasks:
+
+   - name: install git
+     action: apt pkg=git state=installed
+     sudo: Yes
+     when: from_github and (ansible_os_family=="Ubuntu" or ansible_os_family=="Debian")
+
+   - name: see if directory already exists
+     stat: path={{openbazaar_toplevel_dest}}/OpenBazaar
+     register: res
+
+#   - debug: var=res
+
+   - name: clone Open Bazaar repo from git repository 
+     shell:  >
+         git clone --depth 1 --branch {{branch}} {{repo_url}} {{openbazaar_toplevel_dest}}/OpenBazaar
+     when: from_github and not res.stat.exists
+
+   - name: copy source code to target host if not getting from github
+     synchronize: src={{copy_from_local_directory}} dest={{openbazaar_toplevel_dest}}/OpenBazaar
+     when: not from_github and not res.stat.exists
+
+   - name: make openbazaar launcher executable
+     shell: chmod +x {{openbazaar_toplevel_dest}}/OpenBazaar/openbazaar
+
+   - name: Update system
+     shell: apt-get update
+     sudo: Yes
+     when: do_system_update
+
+   - name: Install list of packages
+     action: apt pkg={{item}} state=installed
+     sudo: Yes
+     with_items: reqs
+     when: ansible_os_family=="Ubuntu" or ansible_os_family=="Debian"
+
+   - name: see if virtual env directory exists
+     stat: path={{openbazaar_python_venv}}
+     register: res
+
+   - name: Create a virtual env if not exists 
+     shell: virtualenv --python=python2.7 {{openbazaar_python_venv}}
+     when: not res.stat.exists
+
+   - name: Install python requirements
+     pip: executable="{{openbazaar_python_venv}}"/bin/pip requirements={{openbazaar_toplevel_dest}}/OpenBazaar/requirements.txt
+
+   - name: Install test requirements
+     pip: executable="{{openbazaar_python_venv}}"/bin/pip requirements={{openbazaar_toplevel_dest}}/OpenBazaar/test_requirements.txt
+     when: do_test 
+
+   - name: Stop Open Bazaar daemon (if it's not running, nothing will happen)
+     action: > 
+      command sh -c "cd {{openbazaar_toplevel_dest}}/OpenBazaar/; ./openbazaar stop" 
+
+   - name: Launch open Bazaar daemon (redirect stdin, stdout, stderr to daemonize)
+     # need to cd to OpenBazaar directory because the launch script assumes the relative python env path
+     action: > 
+       command sh -c "cd {{openbazaar_toplevel_dest}}/OpenBazaar/; nohup ./openbazaar  start --disable-open-browser -j --http-ip {{ip}} --http-port {{port}} 2>&1 >/dev/null &"
+     register: result
+
+   - name: Wait for port to become available
+     wait_for: port={{port}} delay=1


### PR DESCRIPTION
Working on https://github.com/OpenBazaar/OpenBazaar/issues/986
Goal is to have automatic setup +deploy ansible scripts for all architectures we want to support. We can have one setup.yml which will do slightly different things depending on the architecture. Some questions that came up:

-Do we want to support CentOS? - It is possible to have python2.7 there as well via anaconda.
-What happens when I want to include an Apache 2.0 snippet of code in this project, which I've modified (in this case the miniconda-centos role) ? I will ofc do a PR on the original repo to contribute to them as well.

Ansible works with vagrant (and apparently [docker](http://www.ansible.com/docker) but haven't tried it)