### PR TITLE
Replaced python-zmq with libzmq3-dev for ubuntu install.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -116,7 +116,7 @@ function installUbuntu {
   set -x
 
   sudo apt-get -q update || echo 'apt-get update failed. Continuing...'
-  sudo apt-get -y install python-pip build-essential python-zmq rng-tools \
+  sudo apt-get -y install python-pip build-essential libzmq3-dev rng-tools \
   python-dev libjpeg-dev sqlite3 openssl \
   alien libssl-dev python-virtualenv lintian libjs-jquery
 


### PR DESCRIPTION
This should presumably fix issues #1049 and #1050 
One problem: 

    Warning: Detected ZMQ version: 4.0.4, but pyzmq targets ZMQ 4.0.5.
    Warning: libzmq features and fixes introduced after 4.0.4 will be unavailable.

Edited: 
But ubuntu does not offer a newer version of ZMQ, as far as I can tell, and the current python-zmq thing doesn't get linked up to from the /env pyzmq thing which, according to the issues mentioned above, is causing problems. I don't think that the warnings should be a problem, but I don't know if anyone has implemented features in 4.0.5 that aren't in 4.0.4. Kind of doubt it, but it's important to mention anyway. A few errors are currently thrown using python-zmq because the pyzmq pip package doesn't seem to link up with the system bindings, as is, which this should fix though. I think. I tested this like 2 weeks ago and it worked on a fresh xubuntu VM.

Edit 2: Just tested on fresh xubuntu, seems to work for me. 