### PR TITLE
Changed license.md to license.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
 The MIT License
-===============
 
 Copyright (C) 2014-2015 OpenBazaar Developers
 


### PR DESCRIPTION
For cross-platform support. TXT files are more commonly readable than markdown files.