### PR TITLE
comment out "set -x"

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -113,7 +113,7 @@ function doneMessage {
 
 function installUbuntu {
   # print commands
-  set -x
+  # set -x
 
   sudo apt-get -q update || echo 'apt-get update failed. Continuing...'
   sudo apt-get -y install python-pip build-essential python-zmq rng-tools \
@@ -139,7 +139,7 @@ function installArch {
     sudo pacman -Syu
   else
     echo "Continuing."
-  fi 
+  fi
   # sudo pacman -S --needed base-devel
   # Can conflict with multilib packages. Uncomment this line if you don't already have base-devel installed
   sudo pacman -S --needed python2 python2-pip python2-virtualenv python2-pyzmq rng-tools libjpeg sqlite3 openssl


### PR DESCRIPTION
Found a fix for #1035. I don't know what `set -x` does, however, commenting it in the Ubuntu install suppresses it from listing the contents of `doneMessage`.

Is `set -x` required? Should it be commented out for all platforms?

Repost of 1155