### PR TITLE
Minor: changed `./configure` message

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -105,14 +105,30 @@ function installMac {
 }
 
 function doneMessage {
-  echo ""
-  echo "OpenBazaar configuration finished."
-  echo "type './openbazaar $1start; tail -F logs/production.log' to start your OpenBazaar servent instance and monitor logging output."
+  VERSION_FROM_CHANGELOG="$(head -1 changelog | awk '/openbazaar \(.*\..*\..*\)/ { print $2 }')"
   echo ""
   echo ""
   echo ""
+  echo '   ____                     ____                            '
+  echo '  / __ \                   |  _ \                           '
+  echo ' | |  | |_ __   ___ _ __   | |_) | __ _ ______ _  __ _ _ __ '
+  echo ' | |  | |  _ \ / _ \  _ \  |  _ < / _` |_  / _` |/ _` |  __|'
+  echo ' | |__| | |_) |  __/ | | | | |_) | (_| |/ / (_| | (_| | |   '
+  echo '  \____/| .__/ \___|_| |_| |____/ \__,_/___\__,_|\__,_|_|   '
+  echo '        | |                                                 '
+  echo '        |_|                                                 '                                                                                                   ##'
   echo ""
+  echo "                                             Release $VERSION_FROM_CHANGELOG"
+  echo ""
+  echo ""
+  echo "OpenBazaar configuration finished!"
+  echo "Run './openbazaar $1start; tail -F logs/production.log' to start OpenBazaar and output logs."
+  echo ""
+  echo ""
+  echo ""
+
 }
+
 
 function installUbuntu {
   # print commands (useful for debugging)


### PR DESCRIPTION
I started with fixing a typo, wound up changing the whole message. Already tested, but it's always nice to have another LGTM. Lemme know if you want a squash. :smile:

The ending configure message now outputs:
```
   ____                     ____                            
  / __ \                   |  _ \                           
 | |  | |_ __   ___ _ __   | |_) | __ _ ______ _  __ _ _ __ 
 | |  | |  _ \ / _ \  _ \  |  _ < / _` |_  / _` |/ _` |  __|
 | |__| | |_) |  __/ | | | | |_) | (_| |/ / (_| | (_| | |   
  \____/| .__/ \___|_| |_| |____/ \__,_/___\__,_|\__,_|_|   
        | |                                                 
        |_|                                                 

                                                    Beta 3.0


OpenBazaar configuration finished!
Run './openbazaar start; tail -F logs/production.log' to start OpenBazaar and output logs.
```