### PR TITLE
bumped version number in debian installer

### DIFF
--- a/installers/ubuntu/DEBIAN/control
+++ b/installers/ubuntu/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: openbazaar
-Version: 0.2.0
+Version: 0.3.0
 Source: openbazaar
 Section: net
 Priority: optional


### PR DESCRIPTION
Quick question though, since the next release will be Beta 4, should this number be 0.4.0 instead? That way when the file's pushed to master it'll automatically be in line with the next release label.