### PR TITLE
Bugfix: Make command line arguments optional

### DIFF
--- a/node/openbazaar.py
+++ b/node/openbazaar.py
@@ -84,7 +84,8 @@ def create_argument_parser():
     parser.add_argument('-l', '--log', default=default_log_path)
 
     # Add valid commands.
-    parser.add_argument('command', choices=('start', 'stop', 'help'))
+    parser.add_argument('command', choices=('start', 'stop', 'help'),
+                        nargs='?', default='help')
 
     return parser
 


### PR DESCRIPTION
When adding the `command` argument, set nargs to '?' (accept 0 or 1) and
make the default command `help` to print usage. This avoids printing an
error when no command is given.