### PR TITLE
Run in foreground by default

### DIFF
--- a/openbazaar
+++ b/openbazaar
@@ -15,8 +15,8 @@ else
   # openbazaar not installed in the system, trying local install
   # with virtual environment first
   if [ -f ./env/bin/python -a -r ./env/bin/python -a -x ./env/bin/python ] ; then
-    ./env/bin/python -m node.openbazaar "$@" &
+    ./env/bin/python -m node.openbazaar "$@"
   else
-    python -m node.openbazaar "$@" &
+    python -m node.openbazaar "$@"
   fi
 fi


### PR DESCRIPTION
Don't start the openbazaar process as a background job. This makes it
easier to keep track of the process when it is run in the terminal.