### PR TITLE
Fix build: Ignore bandit exit status

### DIFF
--- a/scripts/banditcheck.sh
+++ b/scripts/banditcheck.sh
@@ -7,3 +7,7 @@ fi
 
 echo '.: Checking python source files using bandit...'
 bandit -a vuln -c bandit.yaml db/*.py db/migrations/*.py node/*.py tests/*.py
+
+# Since bandit is used for informative purposes only, its exit status
+# should not matter for the build.
+exit 0

--- a/scripts/pycheck.sh
+++ b/scripts/pycheck.sh
@@ -9,7 +9,7 @@ else
     exit 1
 fi
 
-echo '.:Checking python source files...'
+echo '.: Checking python source files...'
 errored=0;
 count=0;
 for file in $(find . -name "*.py" \


### PR DESCRIPTION
### Motivation:
The `bandit` security checker was installed on the build on #1085. Because `bandit` isn't on pypi, we are downloading and installing the latest version. This occasionally causes the build to break, as `bandit` is under active development. This PR causes the build to ignore the exit status of the relevant checking script, which is in line with our policy to using `bandit` only for informative purposes.

### Changelog:
* Force exit status of `scripts/banditcheck.sh` to be `0`.