### PR TITLE
Reduce expensive calls to ioloop.IOLoop.instance()

### DIFF
--- a/node/connection.py
+++ b/node/connection.py
@@ -26,6 +26,8 @@ class PeerConnection(GUIDMixin, object):
 
         self.transport = transport
 
+        self.loop = ioloop.IOLoop.current()
+
         self.log = logging.getLogger(
             '[%s] %s' % (self.transport.market_id, self.__class__.__name__)
         )
@@ -95,7 +97,7 @@ class PeerConnection(GUIDMixin, object):
 
                 self.pinging = False
 
-            ioloop.IOLoop.instance().call_later(10, no_response)
+            self.loop.call_later(10, no_response)
 
         self.seed = False
         self.punching = False
@@ -121,7 +123,7 @@ class PeerConnection(GUIDMixin, object):
 
                     # yappi.get_thread_stats().print_all()
 
-        self.ping_task = ioloop.PeriodicCallback(pinger, 5000, io_loop=ioloop.IOLoop.instance())
+        self.ping_task = ioloop.PeriodicCallback(pinger, 5000, io_loop=self.loop)
         self.ping_task.start()
 
     def setup_emitters(self):
@@ -223,7 +225,7 @@ class PeerConnection(GUIDMixin, object):
                         self.send_to_rudp(serialized)
                         return
 
-            ioloop.IOLoop.instance().call_later(5, sending_out)
+            self.loop.call_later(5, sending_out)
 
         sending_out()
 

--- a/node/market.py
+++ b/node/market.py
@@ -44,6 +44,8 @@ class Market(object):
           gpg: Public PGP key class
         """
 
+        self.loop = ioloop.IOLoop.current()
+
         # Current
         self.transport = transport
         self.dht = transport.dht
@@ -91,10 +93,9 @@ class Market(object):
 
     def start_listing_republisher(self):
         # Periodically refresh buckets
-        loop = ioloop.IOLoop.instance()
         refresh_cb = ioloop.PeriodicCallback(self.dht._refresh_node,
                                              constants.REFRESH_TIMEOUT,
-                                             io_loop=loop)
+                                             io_loop=self.loop)
         refresh_cb.start()
 
     def disable_welcome_screen(self):

--- a/node/openbazaar_daemon.py
+++ b/node/openbazaar_daemon.py
@@ -314,7 +314,7 @@ class MarketApplication(tornado.web.Application):
             )
 
         self.cleanup_upnp_port_mapping()
-        tornado.ioloop.IOLoop.instance().stop()
+        self.loop.stop()
 
         self.transport.shutdown()
         self.shutdown_mutex.release()

--- a/node/transport.py
+++ b/node/transport.py
@@ -77,7 +77,7 @@ class CryptoTransportLayer(TransportLayer):
     def __init__(self, ob_ctx, db_connection):
 
         self.ob_ctx = ob_ctx
-
+        self.loop = ioloop.IOLoop.current()
         self.log = logging.getLogger(
             '[%s] %s' % (ob_ctx.market_id, self.__class__.__name__)
         )
@@ -127,10 +127,11 @@ class CryptoTransportLayer(TransportLayer):
         TransportLayer.__init__(self, ob_ctx, self.guid, self.nickname, self.avatar_url)
         self.start_listener()
 
+        self.ip_checker_caller = None
         if ob_ctx.enable_ip_checker and not ob_ctx.seed_mode and not ob_ctx.dev_mode:
             self.start_ip_address_checker()
 
-        # ioloop.IOLoop.instance().call_later(5, self.truncate_dead_peers)
+        # self.loop.call_later(5, self.truncate_dead_peers)
 
     def truncate_dead_peers(self):
         for peer in self.dht.active_peers:
@@ -172,7 +173,7 @@ class CryptoTransportLayer(TransportLayer):
                     #     peer.sock.sendto('heartbeat', (peer.hostname, peer.port))
 
                     # Heartbeat to relay server
-                    # PeriodicCallback(heartbeat, 5000, ioloop.IOLoop.instance()).start()
+                    # PeriodicCallback(heartbeat, 5000, self.loop).start()
 
     def get_nat_type(self, guid):
         self.log.debug('Requesting nat type for user: %s', guid)
@@ -346,8 +347,8 @@ class CryptoTransportLayer(TransportLayer):
     def start_ip_address_checker(self):
         '''Checks for possible public IP change'''
         if self.ob_ctx.enable_ip_checker:
-            self.caller = PeriodicCallback(self._ip_updater_periodic_callback, 5000, ioloop.IOLoop.instance())
-            self.caller.start()
+            self.ip_checker_caller = PeriodicCallback(self._ip_updater_periodic_callback, 5000, self.loop)
+            self.ip_checker_caller.start()
             self.log.info("IP_CHECKER_ENABLED: Periodic IP Address Checker started.")
 
     def _ip_updater_periodic_callback(self):
@@ -476,7 +477,7 @@ class CryptoTransportLayer(TransportLayer):
                 }))
                 return
             else:
-                ioloop.IOLoop.instance().call_later(5, send_punches)
+                self.loop.call_later(5, send_punches)
         send_punches()
 
     def validate_on_relay_msg(self, msg):
@@ -529,7 +530,7 @@ class CryptoTransportLayer(TransportLayer):
                 self.log.debug('Sending punch to %s:%d', peer.hostname, peer.port)
                 self.log.debug("UDP punching package %d sent", count)
                 if peer.punching:
-                    ioloop.IOLoop.instance().call_later(0.5, send, count + 1)
+                    self.loop.call_later(0.5, send, count + 1)
                 if count >= 25:
                     if not peer.reachable:
                         self.log.debug('Falling back to relaying.')
@@ -856,7 +857,7 @@ class CryptoTransportLayer(TransportLayer):
             peer_obj.seed = True
             peer_obj.reachable = True  # Seeds should be reachable always
 
-        ioloop.IOLoop.instance().call_later(30, self.search_for_my_node)
+        self.loop.call_later(30, self.search_for_my_node)
 
         if callback is not None:
             callback('Joined')

--- a/rudp/pendingpacket.py
+++ b/rudp/pendingpacket.py
@@ -6,7 +6,7 @@ from tornado import ioloop
 class PendingPacket(object):
 
     def __init__(self, packet, packet_sender):
-
+        self.loop = ioloop.IOLoop.current()
         self.ee = EventEmitter()
 
         self._packet_sender = packet_sender
@@ -36,7 +36,7 @@ class PendingPacket(object):
                 self._packet_sender.send(self._packet)
                 packet_send(counter+1)
             else:
-                ioloop.IOLoop.instance().call_later(5, packet_lost)
+                self.loop.call_later(5, packet_lost)
 
         packet_send(0)
 


### PR DESCRIPTION
IOLoop.instance() is only meant to be used when posting back to the
main thread, invoking this method performs double checks on a critical
code section, too many calls and you can end up on deadlocks.

It is better to use IOLoop.current(), which could in turn use .instance()
only if it were necessary.

I've debugged our code and we only have 3 threads running (according to my PyCharm debugger)

Therefore in most of the cases we're probably making those calls from the
same thread where Tornado's ioLoop thread lives.

I've also reduced the number of calls to IOLoop.current() by keeping a reference
to the loop in the constructor of the classes that need to communicate with it.
In all classes this reference is known as `self.loop`