### PR TITLE
MarketApplication.shutdown() called on SIGINT signal.

### DIFF
--- a/node/openbazaar_daemon.py
+++ b/node/openbazaar_daemon.py
@@ -370,6 +370,7 @@ def attempt_browser_open(ob_ctx):
 def setup_signal_handlers(application):
     try:
         signal.signal(signal.SIGTERM, application.shutdown)
+        signal.signal(signal.SIGINT, application.shutdown)
     except ValueError:
         pass
 


### PR DESCRIPTION
If for some reason an user decides to run the console process in
foreground (without the '&'), and then tries to stop the process
with `Ctrl-C`, we will have a proper shutdown occur.