### PR TITLE
format item buy desc  (Purchase this Contract)

### DIFF
--- a/html/partials/modal/buyItem.html
+++ b/html/partials/modal/buyItem.html
@@ -19,7 +19,7 @@
                                                                style="font-size:20px;font-weight:normal;">{{listing.contract_body.Contract.item_price}} BTC</span>
                 </h3>
 
-            <p style="background-color: #efefef;padding:10px;">{{listing.item_desc}}</p>
+            <p style="white-space: pre-wrap; background-color: #efefef;padding:10px;">{{listing.item_desc}}</p>
 
             <h4>More Information</h4>
             <ul>


### PR DESCRIPTION
now line breaks are working in the item description
(tested under windows with chrome 42)

Before the fix:
![before](https://cloud.githubusercontent.com/assets/1709259/7339126/9bea6ea2-ec63-11e4-973f-587f36653ab6.PNG)

After the fix:
![after](https://cloud.githubusercontent.com/assets/1709259/7339131/ac84dc70-ec63-11e4-891d-a5b0717f4aa2.PNG)
