### PR TITLE
fixed check for keywords on contract save

### DIFF
--- a/html/controllers/contracts.js
+++ b/html/controllers/contracts.js
@@ -236,7 +236,7 @@ angular.module('app')
                             }
                         };
 
-                        var keywords = ($scope.contract.productKeywords) ? $scope.contract.productKeywords.split(',') : [];
+                        var keywords = ($scope.contract.productKeywords[0]) ? $scope.contract.productKeywords.split(',') : [];
                         $.each(keywords, function(i, el) {
                             if ($.inArray(el.trim(), contract.Contract.item_keywords) === -1 && el.trim() !== '') {
                                 contract.Contract.item_keywords.push(el.trim());


### PR DESCRIPTION
Minor bug fix in the 'Save Contract' function.  Ternary operator to check for existence of product keywords always returned true because empty array always exists.  The prevented the contract from saving.  Changed to check index 0 of array.
![screen shot 2015-05-08 at 7 39 02 am](https://cloud.githubusercontent.com/assets/6912719/7538519/5a54aed0-f555-11e4-9bb7-d0481092fc0e.png)
