### PR TITLE
Peers should only relay reachable close nodes

### DIFF
--- a/node/constants.py
+++ b/node/constants.py
@@ -90,3 +90,5 @@ MSG_SEND_RELAY_PONG_ID = 'send_relay_pong'
 MSG_HEARTBEAT_ID = 'heartbeat'
 MSG_RELAYTO_ID = 'relayto'
 MSG_RELAY_ID = 'relay '  # Trailing space is intentional.
+
+CLOSE_NODE_TIMELIMIT_IN_SECONDS = 5*60

--- a/node/dht.py
+++ b/node/dht.py
@@ -242,20 +242,26 @@ class DHT(object):
         contacts = self.routing_table.find_close_nodes(key, constants.K, guid)
         contact_list = []
         for contact in contacts:
-            self.log.debug('Contact: %s', contact)
-            contact.avatar_url = contact.avatar_url if contact.avatar_url else None
 
-            contact_list.append((
-                contact.guid,
-                contact.hostname,
-                contact.port,
-                contact.pub,
-                contact.nickname,
-                contact.nat_type,
-                contact.avatar_url
-            ))
+            stale_contact_time = time.time() - constants.CLOSE_NODE_TIMELIMIT_IN_SECONDS
 
-        return self.dedupe(contact_list)
+            if contact.last_reached > stale_contact_time:
+
+                contact.avatar_url = contact.avatar_url if contact.avatar_url else None
+
+                contact_list.append((
+                    contact.guid,
+                    contact.hostname,
+                    contact.port,
+                    contact.pub,
+                    contact.nickname,
+                    contact.nat_type,
+                    contact.avatar_url
+                ))
+
+        close_nodes = self.dedupe(contact_list)
+
+        return close_nodes
 
     @_synchronized
     def on_find_node_response(self, msg):


### PR DESCRIPTION
This fix implements a new constant for close node info timeout. Right now if your node issues a key search against the DHT and it's not found by a peer they will return close nodes no matter if they're reachable or not. This imposes a 15 minute limit for when the peer was last seen. This should cut down on peers sending you stale lists of nodes to populate your sidebar.