### PR TITLE
fix for empty keywords on contract creation

### DIFF
--- a/html/controllers/contracts.js
+++ b/html/controllers/contracts.js
@@ -181,6 +181,7 @@ angular.module('app')
                     $scope.contract.productPrice = 0.5;
                     $scope.contract.productShippingPrice = 0;
                     $scope.contract.remoteImages = [];
+                    $scope.contract.productKeywords = [];
                     $scope.edit = false;
                     $scope.last_price_usd = scope.$parent.last_price_usd;
                     $scope.last_price_eur = scope.$parent.last_price_eur;


### PR DESCRIPTION
Initialize $scope.contract.productKeywords as an empty array when opening modal to create a new contract.