### PR TITLE
Prevent a GPG key generation input exception on missing logname and username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get install -y alien libssl-dev wget lintian libjs-jquery curl
 #
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
 
-
 ADD ./requirements.txt /bazaar/
 RUN cd /bazaar && pip install -r requirements.txt
 
 ADD . /bazaar
 
+ENV LOGNAME openbazaar
 ENV RUNSH_ARGS -q 8888 -p 12345
 
 WORKDIR /bazaar


### PR DESCRIPTION
Workaround for [issue 28 in python-gnupg 1.3.7](https://bitbucket.org/vinay.sajip/python-gnupg/issue/28)

Alternatively, the issue could be solved by setting os.environ['LOGNAME'] directly before the gpg call in node/transport.py. 