### PR TITLE
Remove pybitmessage submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pybitmessage"]
-	path = pybitmessage
-	url = https://github.com/Bitmessage/PyBitmessage.git

--- a/scripts/jscheck.sh
+++ b/scripts/jscheck.sh
@@ -11,7 +11,6 @@ count=0;
 errored=0;
 for file in $(find . -name '*.js' -not -name '*.min.js' \
     -not -path './env/*' \
-    -not -path './pybitmessage/*' \
     -not -path './html/bower_components/*' \
     -not -path './html/vendors/*'); do
     if ! jshint "$file"; then

--- a/scripts/nlcheck.sh
+++ b/scripts/nlcheck.sh
@@ -3,7 +3,7 @@
 echo '.: Checking for newlines at EOFs...'
 count=0;
 errored=0;
-for file in $(find . -not -path './env/*' -not -path './pybitmessage/*' \
+for file in $(find . -not -path './env/*' \
     -and '(' -name '*.html' -o -name '*.js' ')' -not -name '*.min.js' \
     | grep -v bower_components); do
     if [ "$(tail -c1 "$file")" != '' ]; then

--- a/scripts/pycheck.sh
+++ b/scripts/pycheck.sh
@@ -14,8 +14,7 @@ errored=0;
 count=0;
 for file in $(find . -name "*.py" \
     -not -path "./env/*" \
-    -not -path "./html/bower_components/*" \
-    -not -path "./pybitmessage/*"); do
+    -not -path "./html/bower_components/*"); do
     if ! $PYLINT --rcfile .pylintrc $file; then
         errored=$((errored + 1));
     fi


### PR DESCRIPTION
### Changelog
* Remove unused `pybitmessage` git submodule.
* Remove references of `pybitmessage` in scripting files.

### Notes
This PR does not remove any of the numerous (albeit non-functional) references to bitmessage inside `node`. This will be done carefully in a future PR, because there may be backwards-incompatible changes in some critical modules, e.g. the launcher.  