### PR TITLE
Critical Bug that Causes New GUID Everytime

### DIFF
--- a/node/transport.py
+++ b/node/transport.py
@@ -765,7 +765,7 @@ class CryptoTransportLayer(TransportLayer):
         self.pubkey = self.settings.get('pubkey', '')
         self.cryptor = Cryptor(pubkey_hex=self.pubkey, privkey_hex=self.secret)
 
-        if not self.guid:
+        if not self.settings.get('guid'):
             self._setup_guid()
 
         self.guid = self.settings.get('guid', '')


### PR DESCRIPTION
This value is always empty string and will generate a new GUID every time you start up the client.

@gubatron @Renelvon @drwasho @SamPatt 

This is a critical bug and should be pushed asap.