### PR TITLE
re #1373: Obdb.select_entries() returns a list of dict objects, not a…

### DIFF
--- a/node/market.py
+++ b/node/market.py
@@ -221,7 +221,10 @@ class Market(object):
         self.log.debug('Generating new pubkey for contract')
 
         # Retrieve next key id from DB
-        next_key_id = int(self.db_connection.select_entries("keystore", select_fields="id")) + 1
+        try:
+            next_key_id = int(self.db_connection.select_entries("keystore", order='DESC', limit=1, select_fields="id")[0]['id']) + 1
+        except IndexError:
+            next_key_id = 1
 
         # Store updated key in DB
         self.db_connection.insert_entry(

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -16,7 +16,7 @@ class TestMarket(unittest.TestCase):
         self.transport.market_id = 1
         self.transport.settings = self.settings_mock
         self.db_mock = mock.MagicMock(spec=db_store.Obdb)
-        self.db_mock.select_entries.return_value = '6'
+        self.db_mock.select_entries.return_value = [{'id': '6'}]
         self.test_market = Market(self.transport, self.db_mock)
 
     def test_init(self):
@@ -163,9 +163,9 @@ class TestMarket(unittest.TestCase):
             "contracts", {"deleted": "0"})
 
     def test_ensure_pubkey_uses_correct_keystore_id(self):
-        self.db_mock.select_entries.return_value = '4'
+        self.db_mock.select_entries.return_value = [{'id': '4'}]
         four = self.test_market.generate_new_pubkey(4)
-        self.db_mock.select_entries.return_value = '5'
+        self.db_mock.select_entries.return_value = [{'id': '5'}]
         five = self.test_market.generate_new_pubkey(5)
         self.assertNotEqual(four, five)
 


### PR DESCRIPTION
Obdb.select_entries() returns a list of rows. We just need max(id), so I use this SQL statement:;
    SELECT id FROM keystore ORDER BY id DESC LIMIT 1;

Passed unit test!